### PR TITLE
Adding a static_transform_publisher in the move_group.launch file

### DIFF
--- a/swiftpro/launch/control.launch
+++ b/swiftpro/launch/control.launch
@@ -2,9 +2,9 @@
 	<param name="robot_description" command="cat $(find swiftpro)/urdf/model.xacro" />
 	<param name="use_gui" value= "False" />
 
-	<node name="swiftpro_write_node" pkg="swiftpro" type="swiftpro_write_node" />
-	<node name="swiftpro_moveit_node" pkg="swiftpro" type="swiftpro_moveit_node" />
-	<node name="swiftpro_rviz_node" pkg="swiftpro" type="swiftpro_rviz_node" />
-	
+	<node name="write" pkg="swiftpro" type="write" />
+	<node name="moveit" pkg="swiftpro" type="moveit" />
+	<node name="rviz" pkg="swiftpro" type="rviz" />
+
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 </launch>

--- a/swiftpro_moveit/launch/move_group.launch
+++ b/swiftpro_moveit/launch/move_group.launch
@@ -25,6 +25,10 @@
     <arg name="pipeline" value="ompl" />
   </include>
 
+  <!-- Broadcasting static tf to link the robot root to the world map -->
+  <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 1 map Base 10" />
+
+
   <!-- Trajectory Execution Functionality -->
   <include ns="move_group" file="$(find swiftpro_moveit)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />


### PR DESCRIPTION
I have added a static_transform_publisher in the launch file that constantly publishes a transformation between a map and the robot base. This removes an error shown when trying to run demo.launch in RViz.

The robot model can now be operated from the RViz environment using the interactive marker. However the robot model isn't currently properly connected as you can see in the attached picture and for some reason moving along Y axis is not possible at the moment. This may have something to do with the joint definitions. 

![moveit](https://user-images.githubusercontent.com/16051701/29239743-f3d8e064-7f5d-11e7-9c33-e120af8d8fa5.png)
