### PR TITLE
Adds dependency on ros-serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ $ git clone https://github.com/uArm-Developer/RosForSwiftAndSwiftPro.git
 ```
 then manually copy package folders *swiftpro* *swift_moveit_config* and *pro_moveit_config* into a catkin_ws/src.
 
-Install ros serial package
-```bash
-$ sudo apt-get install ros-kinetic-serial
+Install dependencies using rosdep
+If running the rosdep for the first time start by running: 
+```
+sudo rosdep init
+rosdep update
+```
+Then isntall all dependencies using:
+```
+rosdep install --from-paths ./ -i
 ```
 
 Compile

--- a/swiftpro/package.xml
+++ b/swiftpro/package.xml
@@ -46,12 +46,14 @@
   <build_depend>message_generation</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>serial</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>serial</run_depend>
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->


### PR DESCRIPTION
- Adds dependency on ros-serial into the ```package.xml```.
- Updates readme to use rosdep for installing dependencies (as defined in package.xml).

Also tested with catkintools.