### PR TITLE
Fixed swiftpro code and launch files to be more ROS-like and not hard…

### DIFF
--- a/swiftpro/launch/pro_control.launch
+++ b/swiftpro/launch/pro_control.launch
@@ -1,10 +1,15 @@
 <launch>
-	<param name="robot_description" command="cat $(find swiftpro)/urdf/pro_model.xacro" />
+	<param name="robot_description" command="cat $(find propro)/urdf/pro_model.xacro" />
 	<param name="use_gui" value= "False" />
+        <param name="port" value="/dev/ttyUSB0" />
 
-	<node name="swiftpro_write_node" pkg="swiftpro" type="swiftpro_write_node"/>
-	<node name="swiftpro_moveit_node" pkg="swiftpro" type="swiftpro_moveit_node"/>
-	<node name="swiftpro_rviz_node" pkg="swiftpro" type="swiftpro_rviz_node"/>
+	<node name="swiftpro_rviz_node" pkg="swiftpro" type="swiftpro_rviz_node" />
+	<node name="swiftpro_read_node"
+              pkg="swiftpro"
+              type="swiftpro_read_node"> 
+              args="$(port)"
+        </node>
 	
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+	<node name="rviz" pkg="rviz" type="rviz" />
 </launch>

--- a/swiftpro/launch/pro_display.launch
+++ b/swiftpro/launch/pro_display.launch
@@ -1,9 +1,14 @@
 <launch>
-	<param name="robot_description" command="cat $(find swiftpro)/urdf/pro_model.xacro" />
+	<param name="robot_description" command="cat $(find propro)/urdf/pro_model.xacro" />
 	<param name="use_gui" value= "False" />
+        <param name="port" value="/dev/ttyUSB0" />
 
 	<node name="swiftpro_rviz_node" pkg="swiftpro" type="swiftpro_rviz_node" />
-	<node name="swiftpro_read_node" pkg="swiftpro" type="swiftpro_read_node" />
+	<node name="swiftpro_read_node"
+              pkg="swiftpro"
+              type="swiftpro_read_node"> 
+              args="$(port)"
+        </node>
 	
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" />

--- a/swiftpro/launch/swift_control.launch
+++ b/swiftpro/launch/swift_control.launch
@@ -1,8 +1,15 @@
 <launch>
+        <arg name="port" default="/dev/ttyUSB0" />
 	<param name="robot_description" command="cat $(find swiftpro)/urdf/swift_model.xacro" />
 	<param name="use_gui" value= "False" />
 
-	<node name="swiftpro_write_node" pkg="swiftpro" type="swiftpro_write_node" />
+	<node 
+              name="swiftpro_write_node" 
+              pkg="swiftpro" 
+              type="swiftpro_write_node">
+              args="$(port)"
+         </node>
+      
 	<node name="swiftpro_moveit_node" pkg="swiftpro" type="swiftpro_moveit_node" />
 	<node name="swiftpro_rviz_node" pkg="swiftpro" type="swiftpro_rviz_node" />
 	

--- a/swiftpro/launch/swift_display.launch
+++ b/swiftpro/launch/swift_display.launch
@@ -1,9 +1,14 @@
 <launch>
 	<param name="robot_description" command="cat $(find swiftpro)/urdf/swift_model.xacro" />
 	<param name="use_gui" value= "False" />
+        <param name="port" value="/dev/ttyUSB0" />
 
 	<node name="swiftpro_rviz_node" pkg="swiftpro" type="swiftpro_rviz_node" />
-	<node name="swiftpro_read_node" pkg="swiftpro" type="swiftpro_read_node" />
+	<node name="swiftpro_read_node"
+              pkg="swiftpro"
+              type="swiftpro_read_node"> 
+              args="$(port)"
+        </node>
 	
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" />

--- a/swiftpro/src/swiftpro_read_node.cpp
+++ b/swiftpro/src/swiftpro_read_node.cpp
@@ -67,16 +67,25 @@ void handlechar(char c)
 int main(int argc, char** argv)
 {	
 	ros::init(argc, argv, "swiftpro_read_node");
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
 	swiftpro::SwiftproState swiftpro_state;
 	std_msgs::String result;
+
+        std::string param;
+        std::string serport;
 
 	ros::Publisher pub = nh.advertise<swiftpro::SwiftproState>("SwiftproState_topic", 1);
 	ros::Rate loop_rate(20);
 
+         if (nh.getParam("port",param)) {
+            serport.assign(param.c_str());
+        } else {
+            serport="/dev/ttyUSB0";
+        }
+
 	try
 	{
-		_serial.setPort("/dev/ttyACM0");
+		_serial.setPort(serport);
 		_serial.setBaudrate(115200);
 		serial::Timeout to = serial::Timeout::simpleTimeout(1000);
 		_serial.setTimeout(to);

--- a/swiftpro/src/swiftpro_write_node.cpp
+++ b/swiftpro/src/swiftpro_write_node.cpp
@@ -161,7 +161,11 @@ void pump_callback(const swiftpro::status& msg)
 int main(int argc, char** argv)
 {	
 	ros::init(argc, argv, "swiftpro_write_node");
-	ros::NodeHandle nh;
+	ros::NodeHandle nh("~");
+
+        std::string param;    
+        std::string serport;
+
 	swiftpro::SwiftproState swiftpro_state;
 
 	ros::Subscriber sub1 = nh.subscribe("position_write_topic", 1, position_write_callback);
@@ -172,9 +176,16 @@ int main(int argc, char** argv)
 	ros::Publisher 	 pub = nh.advertise<swiftpro::SwiftproState>("SwiftproState_topic", 1);
 	ros::Rate loop_rate(20);
 
+        ROS_INFO("Got parameter: %s", param.c_str());
+        if (nh.getParam("port",param)) {
+            serport.assign(param.c_str());
+        } else {
+            serport="/dev/ttyUSB0";
+        }
+
 	try
 	{
-		_serial.setPort("/dev/ttyACM0");
+		_serial.setPort(serport);
 		_serial.setBaudrate(115200);
 		serial::Timeout to = serial::Timeout::simpleTimeout(1000);
 		_serial.setTimeout(to);


### PR DESCRIPTION
…code the USB device to use to connect to the uArm.
My uArms don't always use /dev/ttyACM0 for the serial port. Sometimes they use /dev/ttyACM1 or ACMn. The Bluetooth dongle shows up as /dev/ttyUSB0 or /dev/ttyUSB1. 

My changes let you specify _port: as a parameter in the launch file which gets passed into the swiftpro read/write programs. 
This would be useful for having multiple USB devices connected to your host system or having multiple uArms connected to a single host via USB. 